### PR TITLE
Improve naming of gopsutil based placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This plugin introduces new placeholders that can be used within Caddy configurat
 | `{extra.caddy.version.full}`   | Full version information of the Caddy server.     |
 | `{extra.rand.float}`           | Random float value between 0.0 and 1.0.           |
 | `{extra.rand.int.0-100}`       | Random integer value between 0 and 100.           |
-| `{extra.load1}`                | System load average over the last 1 minute.       |
-| `{extra.load5}`                | System load average over the last 5 minutes.      |
-| `{extra.load15}`               | System load average over the last 15 minutes.     |
-| `{extra.hostinfo.uptime}`               | System uptime in a human-readable format.         |
+| `{extra.loadavg.1}`            | System load average over the last 1 minute.       |
+| `{extra.loadavg.5}`            | System load average over the last 5 minutes.      |
+| `{extra.loadavg.15}`           | System load average over the last 15 minutes.     |
+| `{extra.hostinfo.uptime}`      | System uptime in a human-readable format.         |
 
 These placeholders can be used in Caddyfiles to provide dynamic content and system information in responses.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This plugin introduces new placeholders that can be used within Caddy configurat
 | `{extra.load1}`                | System load average over the last 1 minute.       |
 | `{extra.load5}`                | System load average over the last 5 minutes.      |
 | `{extra.load15}`               | System load average over the last 15 minutes.     |
-| `{extra.uptime}`               | System uptime in a human-readable format.         |
+| `{extra.hostinfo.uptime}`               | System uptime in a human-readable format.         |
 
 These placeholders can be used in Caddyfiles to provide dynamic content and system information in responses.
 
@@ -38,7 +38,7 @@ To use the extra placeholders, you can add the following directive to your Caddy
 :8080 {
     extra_placeholders
 
-    respond "Caddy Version: {extra.caddy.version.full}, Uptime: {extra.uptime}"
+    respond "Caddy Version: {extra.caddy.version.full}, Uptime: {extra.hostinfo.uptime}"
 }
 ```
 

--- a/extra_placeholders.go
+++ b/extra_placeholders.go
@@ -43,9 +43,9 @@ func init() {
 // `{extra.caddy.version.full}` | Full version information of the Caddy server.
 // `{extra.rand.float}` | Random float value between 0.0 and 1.0.
 // `{extra.rand.int.0-100}` | Random integer value between 0 and 100.
-// `{extra.load1}` | System load average over the last 1 minute.
-// `{extra.load5}` | System load average over the last 5 minutes.
-// `{extra.load15}` | System load average over the last 15 minutes.
+// `{extra.loadavg.1}` | System load average over the last 1 minute.
+// `{extra.loadavg.5}` | System load average over the last 5 minutes.
+// `{extra.loadavg.15}` | System load average over the last 15 minutes.
 // `{extra.hostinfo.uptime}` | System uptime in a human-readable format.
 
 // CaddyModule returns the module information required by Caddy to register the plugin.
@@ -76,9 +76,9 @@ func (ExtraPlaceholders) ServeHTTP(w http.ResponseWriter, r *http.Request, next 
 	// Set placeholders for system load averages (1, 5, and 15 minutes).
 	loadAvg, err := load.Avg()
 	if err == nil {
-		repl.Set("extra.load1", loadAvg.Load1)
-		repl.Set("extra.load5", loadAvg.Load5)
-		repl.Set("extra.load15", loadAvg.Load15)
+		repl.Set("extra.loadavg.1", loadAvg.Load1)
+		repl.Set("extra.loadavg.5", loadAvg.Load5)
+		repl.Set("extra.loadavg.15", loadAvg.Load15)
 	}
 
 	// Set placeholder for system uptime.

--- a/extra_placeholders.go
+++ b/extra_placeholders.go
@@ -39,8 +39,6 @@ func init() {
 
 // Placeholder | Description
 // ------------|-------------
-// `{extra.caddy.version.simple}` | The simple version of the Caddy server.
-
 // `{extra.caddy.version.simple}` | Simple version information of the Caddy server.
 // `{extra.caddy.version.full}` | Full version information of the Caddy server.
 // `{extra.rand.float}` | Random float value between 0.0 and 1.0.
@@ -48,7 +46,7 @@ func init() {
 // `{extra.load1}` | System load average over the last 1 minute.
 // `{extra.load5}` | System load average over the last 5 minutes.
 // `{extra.load15}` | System load average over the last 15 minutes.
-// `{extra.uptime}` | System uptime in a human-readable format.
+// `{extra.hostinfo.uptime}` | System uptime in a human-readable format.
 
 // CaddyModule returns the module information required by Caddy to register the plugin.
 func (ExtraPlaceholders) CaddyModule() caddy.ModuleInfo {
@@ -87,9 +85,9 @@ func (ExtraPlaceholders) ServeHTTP(w http.ResponseWriter, r *http.Request, next 
 	uptime, err := host.Uptime()
 	if err == nil {
 		uptimeDuration := time.Duration(uptime) * time.Second
-		repl.Set("extra.uptime", uptimeDuration.String())
+		repl.Set("extra.hostinfo.uptime", uptimeDuration.String())
 	} else {
-		repl.Set("extra.uptime", "error retrieving uptime")
+		repl.Set("extra.hostinfo.uptime", "error retrieving uptime")
 	}
 
 	// Call the next handler in the chain.


### PR DESCRIPTION
Renaming placeholders:

* `{extra.uptime}` -> `{extra.hostinfo.uptime}`
* `{extra.load1}` -> `{extra.loadavg.1}`
* `{extra.load5}` -> `{extra.loadavg.5}`
* `{extra.load15}` -> `{extra.loadavg.15}`